### PR TITLE
Form Field properties dollar syntax

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "vetur.validation.template": false,
+  "vetur.experimental.templateInterpolationService": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": true
   },

--- a/main/composable/__tests__/useValidation.spec.ts
+++ b/main/composable/__tests__/useValidation.spec.ts
@@ -13,36 +13,36 @@ const testData = [
     () => new Form(),
     () => ({
       foo: {
-        value: 1,
-        rules: []
+        $value: 1,
+        $rules: []
       },
       bar: {
-        value: '2',
-        rules: []
+        $value: '2',
+        $rules: []
       },
       xs: [
         {
           foo: {
-            value: {
+            $value: {
               a: 1,
               b: 2,
               c: {
                 d: 4
               }
             },
-            rules: []
+            $rules: []
           },
           ys: [
             {
               foo: {
-                value: 100,
-                rules: []
+                $value: 100,
+                $rules: []
               }
             },
             {
               foo: {
-                value: 200,
-                rules: []
+                $value: 200,
+                $rules: []
               }
             }
           ]
@@ -55,36 +55,36 @@ const testData = [
     () => new Form(),
     () => ({
       foo: {
-        value: ref(1),
-        rules: []
+        $value: ref(1),
+        $rules: []
       },
       bar: {
-        value: ref('2'),
-        rules: []
+        $value: ref('2'),
+        $rules: []
       },
       xs: [
         {
           foo: {
-            value: ref({
+            $value: ref({
               a: 1,
               b: 2,
               c: {
                 d: 4
               }
             }),
-            rules: []
+            $rules: []
           },
           ys: [
             {
               foo: {
-                value: ref(100),
-                rules: []
+                $value: ref(100),
+                $rules: []
               }
             },
             {
               foo: {
-                value: ref(200),
-                rules: []
+                $value: ref(200),
+                $rules: []
               }
             }
           ]
@@ -99,67 +99,63 @@ describe('transformFormData', () => {
     'should add metadata to all form fields (%s)',
     (_, getForm, getFormData) => {
       const form = getForm();
-      const formData = getFormData() as any;
+      const formData = getFormData();
 
       transformFormData(form, formData);
 
-      // Top level foo
-      expect(formData).toHaveProperty(['foo', 'uid']);
-      expect(typeof formData.foo.uid).toBe('number');
-      expect(formData).toHaveProperty(['foo', 'value'], 1);
-      expect(formData).toHaveProperty(['foo', 'errors']);
-      expect(Array.isArray(formData.foo.errors)).toBe(true);
-      expect(formData).toHaveProperty(['foo', 'validating'], false);
-
-      // Top level bar
-      expect(formData).toHaveProperty(['bar', 'uid']);
-      expect(typeof formData.bar.uid).toBe('number');
-      expect(formData).toHaveProperty(['bar', 'value'], '2');
-      expect(formData).toHaveProperty(['bar', 'errors']);
-      expect(Array.isArray(formData.bar.errors)).toBe(true);
-      expect(formData).toHaveProperty(['bar', 'validating'], false);
-
-      // xs -> 0 -> foo
-      expect(formData).toHaveProperty(['xs', '0', 'foo', 'uid']);
-      expect(typeof formData.xs[0].foo.uid).toBe('number');
-      expect(formData).toHaveProperty(['xs', '0', 'foo', 'value'], {
-        a: 1,
-        b: 2,
-        c: {
-          d: 4
-        }
+      expect(formData).toEqual({
+        foo: {
+          $uid: expect.any(Number),
+          $value: 1,
+          $errors: [],
+          $validating: false,
+          $onBlur: expect.any(Function)
+        },
+        bar: {
+          $uid: expect.any(Number),
+          $value: '2',
+          $errors: [],
+          $validating: false,
+          $onBlur: expect.any(Function)
+        },
+        xs: [
+          {
+            foo: {
+              $uid: expect.any(Number),
+              $value: {
+                a: 1,
+                b: 2,
+                c: {
+                  d: 4
+                }
+              },
+              $errors: [],
+              $validating: false,
+              $onBlur: expect.any(Function)
+            },
+            ys: [
+              {
+                foo: {
+                  $uid: expect.any(Number),
+                  $value: 100,
+                  $errors: [],
+                  $validating: false,
+                  $onBlur: expect.any(Function)
+                }
+              },
+              {
+                foo: {
+                  $uid: expect.any(Number),
+                  $value: 200,
+                  $errors: [],
+                  $validating: false,
+                  $onBlur: expect.any(Function)
+                }
+              }
+            ]
+          }
+        ]
       });
-      expect(formData).toHaveProperty(['xs', '0', 'foo', 'errors']);
-      expect(Array.isArray(formData.xs[0].foo.errors)).toBe(true);
-      expect(formData).toHaveProperty(['xs', '0', 'foo', 'validating'], false);
-
-      // xs -> 0 -> ys -> 0 -> foo
-      expect(formData).toHaveProperty(['xs', '0', 'ys', '0', 'foo', 'uid']);
-      expect(typeof formData.xs[0].ys[0].foo.uid).toBe('number');
-      expect(formData).toHaveProperty(
-        ['xs', '0', 'ys', '0', 'foo', 'value'],
-        100
-      );
-      expect(formData).toHaveProperty(['xs', '0', 'ys', '0', 'foo', 'errors']);
-      expect(Array.isArray(formData.xs[0].ys[0].foo.errors)).toBe(true);
-      expect(formData).toHaveProperty(
-        ['xs', '0', 'ys', '0', 'foo', 'validating'],
-        false
-      );
-
-      // xs -> 0 -> ys -> 1 -> foo
-      expect(formData).toHaveProperty(['xs', '0', 'ys', '1', 'foo', 'uid']);
-      expect(typeof formData.xs[0].ys[1].foo.uid).toBe('number');
-      expect(formData).toHaveProperty(
-        ['xs', '0', 'ys', '1', 'foo', 'value'],
-        200
-      );
-      expect(formData).toHaveProperty(['xs', '0', 'ys', '1', 'foo', 'errors']);
-      expect(Array.isArray(formData.xs[0].ys[0].foo.errors)).toBe(true);
-      expect(formData).toHaveProperty(
-        ['xs', '0', 'ys', '1', 'foo', 'validating'],
-        false
-      );
     }
   );
 });
@@ -248,17 +244,23 @@ describe('useValidation', () => {
           b: {
             c: {
               d: {
-                e: {
-                  value: {
-                    foo: '',
-                    bar: 10
+                value: {
+                  e: {
+                    $value: {
+                      foo: '',
+                      bar: ref(10)
+                    }
                   }
                 }
               }
             }
           },
           f: {
-            value: ''
+            $value: '',
+            $rules: [],
+            x: 1,
+            y: 2,
+            z: 3
           }
         }
       });
@@ -268,25 +270,27 @@ describe('useValidation', () => {
           b: {
             c: {
               d: {
-                e: {
-                  uid: expect.any(Number),
-                  value: {
-                    foo: '',
-                    bar: 10
-                  },
-                  errors: [],
-                  validating: false,
-                  onBlur: expect.any(Function)
+                value: {
+                  e: {
+                    $uid: expect.any(Number),
+                    $value: {
+                      foo: '',
+                      bar: 10
+                    },
+                    $errors: [],
+                    $validating: false,
+                    $onBlur: expect.any(Function)
+                  }
                 }
               }
             }
           },
           f: {
-            uid: expect.any(Number),
-            value: '',
-            errors: [],
-            validating: false,
-            onBlur: expect.any(Function)
+            $uid: expect.any(Number),
+            $value: '',
+            $errors: [],
+            $validating: false,
+            $onBlur: expect.any(Function)
           }
         }
       });
@@ -294,10 +298,10 @@ describe('useValidation', () => {
       const { form: form2 } = useValidation({
         a: {
           b: {
-            value: 1
+            $value: 1
           },
           c: {
-            value: 2
+            $value: 2
           }
         },
         ds: [
@@ -305,10 +309,10 @@ describe('useValidation', () => {
             e: {
               f: {
                 g: {
-                  value: 'foo'
+                  $value: 'foo'
                 },
                 e: {
-                  value: 'bar'
+                  $value: 'bar'
                 }
               }
             }
@@ -317,10 +321,10 @@ describe('useValidation', () => {
             e: {
               f: {
                 g: {
-                  value: 'abc'
+                  $value: 'abc'
                 },
                 e: {
-                  value: 'def'
+                  $value: 'def'
                 }
               }
             }
@@ -331,18 +335,18 @@ describe('useValidation', () => {
       expect(form2).toEqual({
         a: {
           b: {
-            uid: expect.any(Number),
-            value: 1,
-            errors: [],
-            validating: false,
-            onBlur: expect.any(Function)
+            $uid: expect.any(Number),
+            $value: 1,
+            $errors: [],
+            $validating: false,
+            $onBlur: expect.any(Function)
           },
           c: {
-            uid: expect.any(Number),
-            value: 2,
-            errors: [],
-            validating: false,
-            onBlur: expect.any(Function)
+            $uid: expect.any(Number),
+            $value: 2,
+            $errors: [],
+            $validating: false,
+            $onBlur: expect.any(Function)
           }
         },
         ds: [
@@ -350,18 +354,18 @@ describe('useValidation', () => {
             e: {
               f: {
                 g: {
-                  uid: expect.any(Number),
-                  value: 'foo',
-                  errors: [],
-                  validating: false,
-                  onBlur: expect.any(Function)
+                  $uid: expect.any(Number),
+                  $value: 'foo',
+                  $errors: [],
+                  $validating: false,
+                  $onBlur: expect.any(Function)
                 },
                 e: {
-                  uid: expect.any(Number),
-                  value: 'bar',
-                  errors: [],
-                  validating: false,
-                  onBlur: expect.any(Function)
+                  $uid: expect.any(Number),
+                  $value: 'bar',
+                  $errors: [],
+                  $validating: false,
+                  $onBlur: expect.any(Function)
                 }
               }
             }
@@ -370,18 +374,18 @@ describe('useValidation', () => {
             e: {
               f: {
                 g: {
-                  uid: expect.any(Number),
-                  value: 'abc',
-                  errors: [],
-                  validating: false,
-                  onBlur: expect.any(Function)
+                  $uid: expect.any(Number),
+                  $value: 'abc',
+                  $errors: [],
+                  $validating: false,
+                  $onBlur: expect.any(Function)
                 },
                 e: {
-                  uid: expect.any(Number),
-                  value: 'def',
-                  errors: [],
-                  validating: false,
-                  onBlur: expect.any(Function)
+                  $uid: expect.any(Number),
+                  $value: 'def',
+                  $errors: [],
+                  $validating: false,
+                  $onBlur: expect.any(Function)
                 }
               }
             }
@@ -392,52 +396,27 @@ describe('useValidation', () => {
   });
 
   describe('onSubmit', () => {
-    it('should discard everything except the value properties', () => {
-      const { onSubmit: onSubmit1 } = useValidation({
+    it('should discard everything except the value properties', done => {
+      const { onSubmit } = useValidation({
         a: {
           b: {
-            c: {
-              d: {
-                e: {
-                  value: {
-                    foo: '',
-                    bar: 10
-                  }
+            $value: 1
+          },
+          c: {
+            $value: {
+              a: {
+                b: {
+                  c: ref(2)
                 }
               }
             }
-          },
-          f: {
-            value: ''
           }
-        }
-      });
-
-      onSubmit1(formData => {
-        expect(formData).toEqual({
-          a: {
-            b: {
-              c: {
-                d: {
-                  e: {
-                    foo: '',
-                    bar: 10
-                  }
-                }
-              }
-            },
-            f: ''
-          }
-        });
-      });
-
-      const { onSubmit: onSubmit2 } = useValidation({
-        a: {
-          b: {
-            value: 1
-          },
-          c: {
-            value: 2
+        },
+        rules: {
+          value: {
+            value: {
+              xs: []
+            }
           }
         },
         ds: [
@@ -445,10 +424,10 @@ describe('useValidation', () => {
             e: {
               f: {
                 g: {
-                  value: 'foo'
+                  $value: 'foo'
                 },
                 e: {
-                  value: 'bar'
+                  $value: 'bar'
                 }
               }
             }
@@ -457,10 +436,13 @@ describe('useValidation', () => {
             e: {
               f: {
                 g: {
-                  value: 'abc'
+                  $value: 'abc',
+                  x: '',
+                  y: '',
+                  z: ''
                 },
                 e: {
-                  value: 'def'
+                  $value: 'def'
                 }
               }
             }
@@ -468,11 +450,24 @@ describe('useValidation', () => {
         ]
       });
 
-      onSubmit2(formData => {
+      onSubmit(formData => {
         expect(formData).toEqual({
           a: {
             b: 1,
-            c: 2
+            c: {
+              a: {
+                b: {
+                  c: 2
+                }
+              }
+            }
+          },
+          rules: {
+            value: {
+              value: {
+                xs: []
+              }
+            }
           },
           ds: [
             {
@@ -493,46 +488,8 @@ describe('useValidation', () => {
             }
           ]
         });
-      });
 
-      const { onSubmit: onSubmit3 } = useValidation({
-        as: [],
-        bs: [
-          {
-            c: {
-              value: ''
-            },
-            ds: []
-          },
-          {
-            c: {
-              value: ''
-            },
-            ds: [
-              {
-                e: {
-                  value: 1
-                }
-              }
-            ]
-          }
-        ]
-      });
-
-      onSubmit3(formData => {
-        expect(formData).toEqual({
-          as: [],
-          bs: [
-            {
-              c: '',
-              ds: []
-            },
-            {
-              c: '',
-              ds: [{ e: 1 }]
-            }
-          ]
-        });
+        done();
       });
     });
   });

--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -1,8 +1,5 @@
 <template>
-  <button
-    :class="['button', type, { disabled: $attrs.disabled }]"
-    :type="htmlType"
-  >
+  <button :class="['button', type, { disabled }]" :type="htmlType">
     <slot></slot>
   </button>
 </template>
@@ -23,6 +20,9 @@ export default defineComponent({
       default: 'default',
       validator: (type: string) =>
         ['default', 'primary', 'danger'].includes(type)
+    },
+    disabled: {
+      type: Boolean
     }
   }
 });
@@ -35,7 +35,7 @@ export default defineComponent({
 }
 
 .disabled {
-  @apply bg-gray-300 border-gray-500 cursor-not-allowed !important;
+  @apply bg-gray-300 border-gray-500 cursor-not-allowed shadow-none !important;
   opacity: 0.3;
 }
 

--- a/src/components/TheNav.vue
+++ b/src/components/TheNav.vue
@@ -2,26 +2,64 @@
   <div class="cont border-r">
     <nav class="nav">
       <router-link
-        class="block relative py-3 pl-16"
+        class="block relative"
         exact-active-class="nav-link-active"
         to="/"
       >
-        <span @click="demoMenu.active = false">Login Form</span>
+        <div class="py-3 pl-16" @click="inactiveAll()">Home</div>
       </router-link>
-      <router-link
-        class="block relative py-3 pl-16"
-        exact-active-class="nav-link-active"
-        to="/dynamic-form"
+
+      <!-- Form sub menu -->
+      <div
+        class="py-3 pl-16 font-semibold cursor-pointer"
+        :class="{ 'text-green-500': formMenu.active }"
+        @click="formMenu.open = !formMenu.open"
       >
-        <span @click="demoMenu.active = false">Dynamic Form</span>
-      </router-link>
-      <router-link
-        class="block relative py-3 pl-16"
-        exact-active-class="nav-link-active"
-        to="/nested-form"
-      >
-        <span @click="demoMenu.active = false">Nested form</span>
-      </router-link>
+        Forms
+      </div>
+      <div v-if="formMenu.open">
+        <router-link
+          class="block relative"
+          exact-active-class="nav-link-active"
+          to="/login-form"
+        >
+          <div class="py-3 pl-20" @click="setFormMenuActive()">Login Form</div>
+        </router-link>
+        <router-link
+          class="block relative"
+          exact-active-class="nav-link-active"
+          to="/dynamic-form"
+        >
+          <div class="py-3 pl-20" @click="setFormMenuActive()">
+            Dynamic Form
+          </div>
+        </router-link>
+        <router-link
+          class="block relative"
+          exact-active-class="nav-link-active"
+          to="/nested-form"
+        >
+          <div class="py-3 pl-20" @click="setFormMenuActive()">Nested Form</div>
+        </router-link>
+        <router-link
+          class="block relative"
+          exact-active-class="nav-link-active"
+          to="/test-form"
+        >
+          <div class="py-3 pl-20" @click="setFormMenuActive()">Test Form</div>
+        </router-link>
+        <router-link
+          class="block relative"
+          exact-active-class="nav-link-active"
+          to="/another-test-form"
+        >
+          <div class="py-3 pl-20" @click="setFormMenuActive()">
+            Another Form
+          </div>
+        </router-link>
+      </div>
+
+      <!-- Demo sub menu -->
       <div
         class="py-3 pl-16 font-semibold cursor-pointer"
         :class="{ 'text-green-500': demoMenu.active }"
@@ -31,11 +69,11 @@
       </div>
       <div v-if="demoMenu.open">
         <router-link
-          class="block relative py-3 pl-20"
+          class="block relative"
           exact-active-class="nav-link-active"
           to="/button-demo"
         >
-          <span @click="demoMenu.active = true">Button demo</span>
+          <div class="py-3 pl-20" @click="setDemoMenuActive()">Button Demo</div>
         </router-link>
       </div>
     </nav>
@@ -51,8 +89,26 @@ export default defineComponent({
       demoMenu: {
         open: true,
         active: false
+      },
+      formMenu: {
+        open: true,
+        active: false
       }
     };
+  },
+  methods: {
+    inactiveAll() {
+      this.formMenu.active = false;
+      this.demoMenu.active = false;
+    },
+    setFormMenuActive() {
+      this.formMenu.active = true;
+      this.demoMenu.active = false;
+    },
+    setDemoMenuActive() {
+      this.demoMenu.active = true;
+      this.formMenu.active = false;
+    }
   }
 });
 </script>

--- a/src/components/form/BaseInput.vue
+++ b/src/components/form/BaseInput.vue
@@ -7,7 +7,7 @@
       class="w-full border border-gray-300 outline-none px-2 py-1 mt-2 input"
       :class="{ error: errors.length > 0 }"
       v-bind="attrsRest"
-      @input="e => $emit('update:modelValue', e.target.value)"
+      v-model="value"
     />
     <div class="mt-2" v-if="errors.length">
       <div class="text-sm text-red-500" v-for="(error, index) in errors">
@@ -27,7 +27,7 @@ export default defineComponent({
       type: String
     },
     modelValue: {
-      type: [String, Number],
+      type: [String, Number, Boolean],
       default: ''
     },
     errors: {
@@ -42,6 +42,16 @@ export default defineComponent({
       attrsClassName,
       attrsRest
     };
+  },
+  computed: {
+    value: {
+      get(): string | number | boolean {
+        return this.modelValue;
+      },
+      set(value: string | number | boolean) {
+        this.$emit('update:modelValue', value);
+      }
+    }
   }
 });
 </script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,12 +1,19 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
+import Home from '../views/Home.vue';
 import LoginForm from '../views/LoginForm.vue';
 import DynamicForm from '../views/DynamicForm.vue';
 import ButtonDemo from '../views/ButtonDemo.vue';
 import NestedForm from '../views/NestedForm.vue';
+import TestForm from '../views/TestForm.vue';
+import AnotherTestForm from '../views/AnotherTestForm.vue';
 
 const routes: RouteRecordRaw[] = [
   {
     path: '/',
+    component: Home
+  },
+  {
+    path: '/login-form',
     component: LoginForm
   },
   {
@@ -20,6 +27,14 @@ const routes: RouteRecordRaw[] = [
   {
     path: '/nested-form',
     component: NestedForm
+  },
+  {
+    path: '/test-form',
+    component: TestForm
+  },
+  {
+    path: '/another-test-form',
+    component: AnotherTestForm
   }
 ];
 

--- a/src/views/AnotherTestForm.vue
+++ b/src/views/AnotherTestForm.vue
@@ -1,0 +1,98 @@
+<template>
+  <h1 class="font-semibold text-2xl">Test Form</h1>
+  <form class="form my-8" @submit.prevent="handleSubmit()">
+    <BaseInput
+      class="mb-4"
+      label="Nested object"
+      v-model="form.nested.$value.a.b.c"
+      :errors="form.nested.$errors"
+      @blur="form.nested.$onBlur()"
+    />
+    <BaseInput
+      class="mb-4"
+      label="Flat string ref"
+      v-model="form.flatRef.$value"
+      :errors="form.flatRef.$errors"
+      @blur="form.flatRef.$onBlur()"
+    />
+    <BaseInput
+      class="mb-8"
+      label="Flat string"
+      v-model="form.flatString.$value"
+      :errors="form.flatString.$errors"
+      @blur="form.flatString.$onBlur()"
+    />
+    <BaseInput
+      class="mb-8"
+      label="Checkbox"
+      type="checkbox"
+      v-model="form.bool.$value"
+      :errors="form.bool.$errors"
+      @blur="form.bool.$onBlur()"
+    />
+    <BaseButton class="w-full" type="primary" htmlType="submit">
+      Submit
+    </BaseButton>
+  </form>
+
+  <pre>{{ form }}</pre>
+</template>
+
+<script lang="ts">
+import BaseInput from '../components/form/BaseInput.vue';
+import BaseButton from '../components/BaseButton.vue';
+import { defineComponent, reactive, ref, watch } from 'vue';
+import { useValidation } from '../../main/composable/useValidation';
+
+export default defineComponent({
+  components: {
+    BaseInput,
+    BaseButton
+  },
+  setup() {
+    const nested = ref('');
+
+    const { form, onSubmit } = useValidation({
+      nested: {
+        $value: {
+          a: {
+            b: {
+              c: nested
+            }
+          }
+        },
+        $rules: [(nested: any) => !nested.a.b.c && 'This field is required']
+      },
+      flatRef: {
+        $value: ref(''),
+        $rules: [(flat: string) => !flat && 'This field is required']
+      },
+      flatString: {
+        $value: '',
+        $rules: [(flat: string) => !flat && 'This field is required']
+      },
+      bool: {
+        $value: false,
+        $rules: [(bool: boolean) => bool || 'Value has to be true']
+      }
+    });
+
+    const handleSubmit = () => {
+      onSubmit(formData => {
+        console.log(JSON.stringify(formData, null, 2));
+      });
+    };
+
+    return {
+      form,
+      handleSubmit
+    };
+  }
+});
+</script>
+
+<style scoped>
+.form {
+  max-width: 900px;
+}
+</style>

--- a/src/views/DynamicForm.vue
+++ b/src/views/DynamicForm.vue
@@ -4,19 +4,19 @@
     <BaseInput
       class="col-span-3"
       label="Profile"
-      v-model="form.profile.value"
-      :errors="form.profile.errors"
-      @blur="form.profile.onBlur()"
+      v-model="form.profile.$value"
+      :errors="form.profile.$errors"
+      @blur="form.profile.$onBlur()"
     />
     <BaseButton @click="addGroup()" class="mt-4 col-span-3">
       Add group
     </BaseButton>
-    <template v-for="(group, groupIndex) in form.groups" :key="group.name.uid">
+    <template v-for="(group, groupIndex) in form.groups" :key="group.name.$uid">
       <BaseInput
         label="Group"
-        v-model="group.name.value"
-        :errors="group.name.errors"
-        @blur="group.name.onBlur()"
+        v-model="group.name.$value"
+        :errors="group.name.$errors"
+        @blur="group.name.$onBlur()"
       />
       <BaseButton @click="addDetail(groupIndex)" class="mt-8 self-start">
         Add detail
@@ -26,19 +26,19 @@
       </BaseButton>
       <template
         v-for="(detail, detailIndex) in group.details"
-        :key="detail.name.uid"
+        :key="detail.name.$uid"
       >
         <BaseInput
           label="Name"
-          v-model="detail.name.value"
-          :errors="detail.name.errors"
-          @blur="detail.name.onBlur()"
+          v-model="detail.name.$value"
+          :errors="detail.name.$errors"
+          @blur="detail.name.$onBlur()"
         />
         <BaseInput
           label="Short"
-          v-model="detail.short.value"
-          :errors="detail.short.errors"
-          @blur="detail.short.onBlur()"
+          v-model="detail.short.$value"
+          :errors="detail.short.$errors"
+          @blur="detail.short.$onBlur()"
         />
         <BaseButton
           @click="removeDetail(groupIndex, detailIndex)"
@@ -85,8 +85,8 @@ export default defineComponent({
   setup() {
     const { form, add, remove, onSubmit } = useValidation<Input>({
       profile: {
-        value: '',
-        rules: [profile => !profile && 'Profile name is required']
+        $value: '',
+        $rules: [profile => !profile && 'Profile name is required']
       },
       groups: []
     });
@@ -94,8 +94,8 @@ export default defineComponent({
     const addGroup = () => {
       add(['groups'], {
         name: {
-          value: '',
-          rules: [(name: string) => !name && 'Group name is required']
+          $value: '',
+          $rules: [(name: string) => !name && 'Group name is required']
         },
         details: []
       });
@@ -108,12 +108,12 @@ export default defineComponent({
     const addDetail = (groupIndex: number) => {
       add(['groups', groupIndex, 'details'], {
         name: {
-          value: '',
-          rules: [(name: string) => !name && 'Detail name is required']
+          $value: '',
+          $rules: [(name: string) => !name && 'Detail name is required']
         },
         short: {
-          value: '',
-          rules: [(short: string) => !short && 'Detail short is required']
+          $value: '',
+          $rules: [(short: string) => !short && 'Detail short is required']
         }
       });
     };
@@ -128,7 +128,7 @@ export default defineComponent({
       submitting.value = true;
       onSubmit(
         formData => {
-          console.log(formData);
+          console.log(JSON.stringify(formData, null, 2));
           submitting.value = false;
         },
         () => {
@@ -152,7 +152,7 @@ export default defineComponent({
 
 <style scoped>
 .form {
-  max-width: 1000px;
+  max-width: 900px;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   row-gap: 10px;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,0 +1,9 @@
+<template>
+  <h1 class="font-semibold text-2xl">Form Validation for Vue 3</h1>
+</template>
+
+<script>
+export default {};
+</script>
+
+<style></style>

--- a/src/views/LoginForm.vue
+++ b/src/views/LoginForm.vue
@@ -4,32 +4,32 @@
     <BaseInput
       class="name input-error"
       label="Name"
-      :errors="form.name.errors"
-      v-model="form.name.value"
-      @blur="form.name.onBlur()"
+      :errors="form.name.$errors"
+      v-model="form.name.$value"
+      @blur="form.name.$onBlur()"
     />
     <BaseInput
       class="mail"
       label="E-Mail"
-      :errors="form.email.errors"
-      v-model="form.email.value"
-      @blur="form.email.onBlur()"
+      :errors="form.email.$errors"
+      v-model="form.email.$value"
+      @blur="form.email.$onBlur()"
     />
     <BaseInput
       class="password"
       label="Password"
       type="password"
-      :errors="form.password.errors"
-      v-model="form.password.value"
-      @blur="form.password.onBlur()"
+      :errors="form.password.$errors"
+      v-model="form.password.$value"
+      @blur="form.password.$onBlur()"
     />
     <BaseInput
       class="repeat-password"
       label="Repeat password"
       type="password"
-      :errors="form.repeatPassword.errors"
-      v-model="form.repeatPassword.value"
-      @blur="form.repeatPassword.onBlur()"
+      :errors="form.repeatPassword.$errors"
+      v-model="form.repeatPassword.$value"
+      @blur="form.repeatPassword.$onBlur()"
     />
     <BaseButton
       class="mt-8"
@@ -66,8 +66,8 @@ export default defineComponent({
 
     const { form, onSubmit } = useValidation<FormData>({
       name: {
-        value: '',
-        rules: [
+        $value: '',
+        $rules: [
           name => !name && 'Name is required',
           name => name.length > 2 || 'Name has to be longer than 2 characters',
           name =>
@@ -83,12 +83,12 @@ export default defineComponent({
         ]
       },
       email: {
-        value: '',
-        rules: [email => !email && 'E-Mail is required']
+        $value: '',
+        $rules: [email => !email && 'E-Mail is required']
       },
       password: {
-        value: password,
-        rules: [
+        $value: password,
+        $rules: [
           pw => pw.length > 7 || 'Password has to be longer than 7 characters',
           {
             key: 'pw',
@@ -99,8 +99,8 @@ export default defineComponent({
         ]
       },
       repeatPassword: {
-        value: repeatPassword,
-        rules: [
+        $value: repeatPassword,
+        $rules: [
           pw => pw.length > 7 || 'Password has to be longer than 7 characters',
           {
             key: 'pw',
@@ -116,7 +116,7 @@ export default defineComponent({
       submitting.value = true;
       onSubmit(
         formData => {
-          console.log(formData);
+          console.log(JSON.stringify(formData, null, 2));
           submitting.value = false;
         },
         () => {
@@ -136,7 +136,7 @@ export default defineComponent({
 
 <style scoped>
 .form {
-  max-width: 1000px;
+  max-width: 900px;
   display: grid;
   column-gap: 25px;
   row-gap: 10px;

--- a/src/views/NestedForm.vue
+++ b/src/views/NestedForm.vue
@@ -1,24 +1,24 @@
 <template>
-  <h1 class="font-semibold text-2xl">Nested form</h1>
+  <h1 class="font-semibold text-2xl">Nested Form</h1>
   <form class="form my-8" @submit.prevent="handleSubmit()">
     <BaseInput
-      label="Nested d"
-      v-model="form.test.a.b.c.d.value"
-      :errors="form.test.a.b.c.d.errors"
-      @blur="form.test.a.b.c.d.onBlur()"
+      label="Nested A"
+      v-model="form.test.a.b.c.d.$value"
+      :errors="form.test.a.b.c.d.$errors"
+      @blur="form.test.a.b.c.d.$onBlur()"
     />
     <BaseInput
-      label="Nested e"
+      label="Nested E"
       type="number"
-      v-model.number="form.test.a.b.e.value"
-      :errors="form.test.a.b.e.errors"
-      @blur="form.test.a.b.e.onBlur()"
+      v-model.number="form.test.a.b.e.$value"
+      :errors="form.test.a.b.e.$errors"
+      @blur="form.test.a.b.e.$onBlur()"
     />
     <BaseInput
-      label="Nested f"
-      v-model.number="form.test.f.value"
-      :errors="form.test.f.errors"
-      @blur="form.test.f.onBlur()"
+      label="Nested F"
+      v-model="form.test.f.$value.foo.a.c"
+      :errors="form.test.f.$errors"
+      @blur="form.test.f.$onBlur()"
     />
     <BaseButton class="mt-8" type="primary" htmlType="submit">
       Submit
@@ -28,7 +28,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, markRaw, reactive, ref, watch } from 'vue';
+import { defineComponent, reactive, ref } from 'vue';
 import BaseInput from '../components/form/BaseInput.vue';
 import BaseButton from '../components/BaseButton.vue';
 import { useValidation, Field } from '../../main/composable/useValidation';
@@ -42,33 +42,41 @@ export default defineComponent({
           b: {
             c: {
               d: {
-                value: '',
-                rules: [(d: string) => !d && 'a is required']
+                $value: '',
+                $rules: [(d: string) => !d && 'a is required']
               }
             },
             e: {
-              value: 0,
-              rules: [(e: number) => !e && 'e is required']
+              $value: (null as unknown) as number,
+              $rules: [(e: number) => !e && 'e is required']
             }
           }
         },
         f: {
-          value: '',
-          rules: [(f: string) => !f && 'f is required']
+          $value: {
+            foo: {
+              a: {
+                c: ''
+              }
+            }
+          },
+          $rules: [
+            (f: { foo: { a: { c: string } } }) => !f.foo.a.c && 'f is required'
+          ]
         }
       },
       xs: [
         {
           a: {
             b: {
-              value: true
+              $value: true
             }
           }
         },
         {
           a: {
             b: {
-              value: true
+              $value: true
             }
           }
         }
@@ -77,7 +85,7 @@ export default defineComponent({
 
     const handleSubmit = () => {
       onSubmit(formData => {
-        console.log(formData);
+        console.log(JSON.stringify(formData, null, 2));
       });
     };
 
@@ -91,7 +99,7 @@ export default defineComponent({
 
 <style scoped>
 .form {
-  max-width: 1000px;
+  max-width: 900px;
   row-gap: 10px;
   display: grid;
 }

--- a/src/views/TestForm.vue
+++ b/src/views/TestForm.vue
@@ -1,0 +1,28 @@
+<template>
+  <h1 class="font-semibold text-2xl">Test Form</h1>
+  <BaseInput type="checkbox" v-model="bool" />
+</template>
+
+<script lang="ts">
+import BaseInput from '../components/form/BaseInput.vue';
+import { defineComponent, reactive, ref, watch } from 'vue';
+
+export default defineComponent({
+  components: {
+    BaseInput
+  },
+  setup() {
+    const bool = ref(false);
+
+    watch(bool, bool => {
+      console.log(bool);
+    });
+
+    return {
+      bool
+    };
+  }
+});
+</script>
+
+<style></style>


### PR DESCRIPTION
`Field` and `TransformedField` properties now start with `$`:
```ts
type Field<T> = {
  value: Ref<T> | T;
  rules?: Rule<T>[];
};

// Changed to:

type Field<T> = {
  $value: Ref<T> | T;
  $rules?: Rule<T>[];
};



type TransformedField<T> = {
  uid: number;
  value: T;
  errors: string[];
  validating: boolean;
  onBlur(): void;
};

// Changed to:

type TransformedField<T> = {
  $uid: number;
  $value: T;
  $errors: string[];
  $validating: boolean;
  $onBlur(): void;
};
```